### PR TITLE
Rename mozilla-japan to webdino

### DIFF
--- a/ansible/files/apache/www/index.html
+++ b/ansible/files/apache/www/index.html
@@ -140,9 +140,9 @@ unsubscribe
             <td>milter-manager@ml.commit-email.info</td>
           </tr>
           <tr>
-            <td><a href="https://github.com/mozilla-japan/">mozilla-japan</a></td>
+            <td><a href="https://github.com/webdino/">webdino</a></td>
             <td>(all)</td>
-            <td>mozilla-japan@ml.commit-email.info</td>
+            <td>webdino@ml.commit-email.info</td>
           </tr>
           <tr>
             <td><a href="https://github.com/mroonga/">mroonga</a></td>

--- a/ansible/files/github-event-watcher/config.yaml
+++ b/ansible/files/github-event-watcher/config.yaml
@@ -5,6 +5,5 @@ repositories:
   - mruby/mruby
   - rails/rails
   - ruby/ruby
-  - mozilla-japan/gecko-embedded
   - speee/webapp-revieee
 webhook-end-point: http://web-hooks-receiver.commit-email.info/

--- a/ansible/files/web-hooks-receiver/config.yaml
+++ b/ansible/files/web-hooks-receiver/config.yaml
@@ -59,9 +59,9 @@ domains:
       milter-manager:
         to:
           - milter-manager@ml.commit-email.info
-      mozilla-japan:
+      webdino:
         to:
-          - mozilla-japan@ml.commit-email.info
+          - webdino@ml.commit-email.info
       mroonga:
         to:
           - mroonga@ml.commit-email.info


### PR DESCRIPTION
In addition remove mozilla-japan/gecko-embedded from
ansible/files/github-event-watcher/config.yaml.

I already added a webhook to the repository.