### PR TITLE
Add rurema

### DIFF
--- a/ansible/files/home/mailer/web-hooks-receiver/config.yaml
+++ b/ansible/files/home/mailer/web-hooks-receiver/config.yaml
@@ -138,6 +138,9 @@ domains:
       ruby-gnome2:
         to:
           - ruby-gnome2@ml.commit-email.info
+      rurema:
+        to:
+          - rurema@ml.commit-email.info
       rwiki:
         to:
           - rwiki@ml.commit-email.info


### PR DESCRIPTION
[Japanese Ruby reference manual project](https://github.com/rurema/doctree/wiki) used QuickML for diff. But diff mails stopped after moving project to github (if my memory is correct).
So I want to restart diff mails.
(ref https://github.com/rurema/doctree/issues/1310 )