### PR TITLE
Add links to generate a mail template to subscribe and unsubscribe for more convinience

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,8 +83,8 @@ class RepositoryListUpdater
               <td><a href="#{owner_url(fqdn, owner)}">#{h(owner)}</a></td>
               <td>#{repository_column}</td>
               <td>#{h(to)}</td>
-              <td><a href="#{mailto_href_subscribe(to)}">Subscribe</a></td>
-              <td><a href="#{mailto_href_unsubscribe(to)}">Unsubscribe</a></td>
+              <td><a href="#{subscribe_url(to)}">Subscribe</a></td>
+              <td><a href="#{unsubscribe_url(to)}">Unsubscribe</a></td>
             </tr>
     ROW
   end
@@ -97,11 +97,11 @@ class RepositoryListUpdater
     "#{owner_url(fqdn, owner)}#{h(repository)}/"
   end
 
-  def mailto_href_subscribe(to)
+  def subscribe_url(to)
     "mailto:#{h(to)}?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe"
   end
 
-  def mailto_href_unsubscribe(to)
+  def unsubscribe_url(to)
     "mailto:#{h(to)}?subject=Unsubscribe"
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -48,6 +48,8 @@ class RepositoryListUpdater
               <th>#{owner_label}</th>
               <th>Repository</th>
               <th>Mailing list</th>
+              <th>Subscribe</th>
+              <th>Unsubscribe</th>
             </tr>
           </thead>
           <tbody>
@@ -80,7 +82,9 @@ class RepositoryListUpdater
             <tr>
               <td><a href="#{owner_url(fqdn, owner)}">#{h(owner)}</a></td>
               <td>#{repository_column}</td>
-              <td><a href="mailto:#{h(to)}?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">#{h(to)}</a></td>
+              <td>#{h(to)}</td>
+              <td><a href="#{mailto_href_subscribe(to)}">Subscribe</a></td>
+              <td><a href="#{mailto_href_unsubscribe(to)}">Unsubscribe</a></td>
             </tr>
     ROW
   end
@@ -91,6 +95,14 @@ class RepositoryListUpdater
 
   def repository_url(fqdn, owner, repository)
     "#{owner_url(fqdn, owner)}#{h(repository)}/"
+  end
+
+  def mailto_href_subscribe(to)
+    "mailto:#{h(to)}?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe"
+  end
+
+  def mailto_href_unsubscribe(to)
+    "mailto:#{h(to)}?subject=Unsubscribe"
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -80,7 +80,7 @@ class RepositoryListUpdater
             <tr>
               <td><a href="#{owner_url(fqdn, owner)}">#{h(owner)}</a></td>
               <td>#{repository_column}</td>
-              <td>#{h(to)}</td>
+              <td><a href="mailto:#{h(to)}?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">#{h(to)}</a></td>
             </tr>
     ROW
   end

--- a/Rakefile
+++ b/Rakefile
@@ -83,8 +83,8 @@ class RepositoryListUpdater
               <td><a href="#{owner_url(fqdn, owner)}">#{h(owner)}</a></td>
               <td>#{repository_column}</td>
               <td>#{h(to)}</td>
-              <td><a href="#{subscribe_url(to)}">Subscribe</a></td>
-              <td><a href="#{unsubscribe_url(to)}">Unsubscribe</a></td>
+              <td><a href="#{h(subscribe_url(to))}">Subscribe</a></td>
+              <td><a href="#{h(unsubscribe_url(to))}">Unsubscribe</a></td>
             </tr>
     ROW
   end
@@ -98,11 +98,11 @@ class RepositoryListUpdater
   end
 
   def subscribe_url(to)
-    "mailto:#{h(to)}?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe"
+    "mailto:#{to}?cc=null@commit-email.info&subject=Subscribe&body=subscribe"
   end
 
   def unsubscribe_url(to)
-    "mailto:#{h(to)}?subject=Unsubscribe"
+    "mailto:#{to}?subject=Unsubscribe"
   end
 end
 

--- a/ansible/files/var/www/html/index.html
+++ b/ansible/files/var/www/html/index.html
@@ -44,6 +44,8 @@ Subject: Subscribe
 --
 subscribe
         </pre>
+
+        <p>* You can get the mail template by clicking the "Subscribe" button in the list and can send it as it is.</p>
       </section>
 
       <section id="unsubscribe">
@@ -62,6 +64,8 @@ To: ruby@ml.commit-email.info
 Subject: Unsubscribe
 --
         </pre>
+
+        <p>* You can get the mail template by clicking the "Unsubscribe" button in the list and can send it as it is.</p>
       </section>
     </section>
 
@@ -77,6 +81,8 @@ Subject: Unsubscribe
               <th>Group</th>
               <th>Repository</th>
               <th>Mailing list</th>
+              <th>Subscribe</th>
+              <th>Unsubscribe</th>
             </tr>
           </thead>
           <tbody>
@@ -84,11 +90,15 @@ Subject: Unsubscribe
               <td><a href="https://gitlab.com/clear-code/">clear-code</a></td>
               <td>(all)</td>
               <td>clear-code@ml.commit-email.info</td>
+              <td><a href="mailto:clear-code@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:clear-code@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://gitlab.com/ktou/">ktou</a></td>
               <td><a href="https://gitlab.com/ktou/www.cozmixng.org/">www.cozmixng.org</a></td>
               <td>cozmixng@ml.commit-email.info</td>
+              <td><a href="mailto:cozmixng@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:cozmixng@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
           </tbody>
         </table>
@@ -102,6 +112,8 @@ Subject: Unsubscribe
               <th>Owner</th>
               <th>Repository</th>
               <th>Mailing list</th>
+              <th>Subscribe</th>
+              <th>Unsubscribe</th>
             </tr>
           </thead>
           <tbody>
@@ -109,256 +121,358 @@ Subject: Unsubscribe
               <td><a href="https://github.com/activeldap/">activeldap</a></td>
               <td>(all)</td>
               <td>activeldap@ml.commit-email.info</td>
+              <td><a href="mailto:activeldap@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:activeldap@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/apache/">apache</a></td>
               <td><a href="https://github.com/apache/arrow/">arrow</a></td>
               <td>apache-arrow@ml.commit-email.info</td>
+              <td><a href="mailto:apache-arrow@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:apache-arrow@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/apache/">apache</a></td>
               <td><a href="https://github.com/apache/arrow-site/">arrow-site</a></td>
               <td>apache-arrow@ml.commit-email.info</td>
+              <td><a href="mailto:apache-arrow@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:apache-arrow@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/apache/">apache</a></td>
               <td><a href="https://github.com/apache/arrow-testing/">arrow-testing</a></td>
               <td>apache-arrow@ml.commit-email.info</td>
+              <td><a href="mailto:apache-arrow@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:apache-arrow@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/apache/">apache</a></td>
               <td><a href="https://github.com/apache/spark/">spark</a></td>
               <td>apache-spark@ml.commit-email.info</td>
+              <td><a href="mailto:apache-spark@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:apache-spark@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/bm-sms/">bm-sms</a></td>
               <td>(all)</td>
               <td>bm-sms@ml.commit-email.info</td>
+              <td><a href="mailto:bm-sms@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:bm-sms@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/clear-code/">clear-code</a></td>
               <td>(all)</td>
               <td>clear-code@ml.commit-email.info</td>
+              <td><a href="mailto:clear-code@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:clear-code@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/clear-code/">clear-code</a></td>
               <td><a href="https://github.com/clear-code/cutter/">cutter</a></td>
               <td>cutter@ml.commit-email.info</td>
+              <td><a href="mailto:cutter@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:cutter@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/clear-code/">clear-code</a></td>
               <td><a href="https://github.com/clear-code/pikzie/">pikzie</a></td>
               <td>pikzie@ml.commit-email.info</td>
+              <td><a href="mailto:pikzie@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:pikzie@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/droonga/">droonga</a></td>
               <td>(all)</td>
               <td>droonga@ml.commit-email.info</td>
+              <td><a href="mailto:droonga@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:droonga@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/fluent/">fluent</a></td>
               <td>(all)</td>
               <td>fluent@ml.commit-email.info</td>
+              <td><a href="mailto:fluent@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:fluent@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/fluent-plugins-nursery/">fluent-plugins-nursery</a></td>
               <td>(all)</td>
               <td>fluent-plugins-nursery@ml.commit-email.info</td>
+              <td><a href="mailto:fluent-plugins-nursery@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:fluent-plugins-nursery@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/groonga/">groonga</a></td>
               <td>(all)</td>
               <td>groonga@ml.commit-email.info</td>
+              <td><a href="mailto:groonga@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:groonga@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/hayamizu-lab/">hayamizu-lab</a></td>
               <td>(all)</td>
               <td>hayamizu-lab@ml.commit-email.info</td>
+              <td><a href="mailto:hayamizu-lab@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:hayamizu-lab@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/kou/">kou</a></td>
               <td><a href="https://github.com/kou/commit-email.info/">commit-email.info</a></td>
               <td>commit-email-info@ml.commit-email.info</td>
+              <td><a href="mailto:commit-email-info@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:commit-email-info@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/kou/">kou</a></td>
               <td><a href="https://github.com/kou/base.cozmixng.org/">base.cozmixng.org</a></td>
               <td>cozmixng@ml.commit-email.info</td>
+              <td><a href="mailto:cozmixng@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:cozmixng@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/kou/">kou</a></td>
               <td><a href="https://github.com/kou/pub.cozmixng.org/">pub.cozmixng.org</a></td>
               <td>cozmixng@ml.commit-email.info</td>
+              <td><a href="mailto:cozmixng@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:cozmixng@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/logaling/">logaling</a></td>
               <td>(all)</td>
               <td>logaling@ml.commit-email.info</td>
+              <td><a href="mailto:logaling@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:logaling@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/milter-manager/">milter-manager</a></td>
               <td>(all)</td>
               <td>milter-manager@ml.commit-email.info</td>
+              <td><a href="mailto:milter-manager@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:milter-manager@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/mroonga/">mroonga</a></td>
               <td>(all)</td>
               <td>mroonga@ml.commit-email.info</td>
+              <td><a href="mailto:mroonga@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:mroonga@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/mruby/">mruby</a></td>
               <td><a href="https://github.com/mruby/mruby/">mruby</a></td>
               <td>mruby@ml.commit-email.info</td>
+              <td><a href="mailto:mruby@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:mruby@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/msgpack/">msgpack</a></td>
               <td>(all)</td>
               <td>msgpack@ml.commit-email.info</td>
+              <td><a href="mailto:msgpack@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:msgpack@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/nroonga/">nroonga</a></td>
               <td>(all)</td>
               <td>nroonga@ml.commit-email.info</td>
+              <td><a href="mailto:nroonga@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:nroonga@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/oss-gate/">oss-gate</a></td>
               <td>(all)</td>
               <td>oss-gate@ml.commit-email.info</td>
+              <td><a href="mailto:oss-gate@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:oss-gate@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/pgroonga/">pgroonga</a></td>
               <td>(all)</td>
               <td>pgroonga@ml.commit-email.info</td>
+              <td><a href="mailto:pgroonga@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:pgroonga@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/piroor/">piroor</a></td>
               <td>(all)</td>
               <td>piroor@ml.commit-email.info</td>
+              <td><a href="mailto:piroor@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:piroor@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/rabbit-shocker/">rabbit-shocker</a></td>
               <td>(all)</td>
               <td>rabbit@ml.commit-email.info</td>
+              <td><a href="mailto:rabbit@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:rabbit@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/rails/">rails</a></td>
               <td><a href="https://github.com/rails/rails/">rails</a></td>
               <td>rails@ml.commit-email.info</td>
+              <td><a href="mailto:rails@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:rails@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/rake-compiler/">rake-compiler</a></td>
               <td>(all)</td>
               <td>rake-compiler@ml.commit-email.info</td>
+              <td><a href="mailto:rake-compiler@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:rake-compiler@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ranguba/">ranguba</a></td>
               <td>(all)</td>
               <td>ranguba@ml.commit-email.info</td>
+              <td><a href="mailto:ranguba@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ranguba@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/rcairo/">rcairo</a></td>
               <td>(all)</td>
               <td>rcairo@ml.commit-email.info</td>
+              <td><a href="mailto:rcairo@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:rcairo@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/red-data-tools/">red-data-tools</a></td>
               <td>(all)</td>
               <td>red-data-tools@ml.commit-email.info</td>
+              <td><a href="mailto:red-data-tools@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:red-data-tools@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/rr/">rr</a></td>
               <td>(all)</td>
               <td>rr@ml.commit-email.info</td>
+              <td><a href="mailto:rr@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:rr@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ruby/">ruby</a></td>
               <td><a href="https://github.com/ruby/csv/">csv</a></td>
               <td>ruby-csv@ml.commit-email.info</td>
+              <td><a href="mailto:ruby-csv@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby-csv@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ruby/">ruby</a></td>
               <td><a href="https://github.com/ruby/fiddle/">fiddle</a></td>
               <td>ruby-fiddle@ml.commit-email.info</td>
+              <td><a href="mailto:ruby-fiddle@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby-fiddle@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ruby/">ruby</a></td>
               <td><a href="https://github.com/ruby/rexml/">rexml</a></td>
               <td>ruby-rexml@ml.commit-email.info</td>
+              <td><a href="mailto:ruby-rexml@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby-rexml@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ruby/">ruby</a></td>
               <td><a href="https://github.com/ruby/rss/">rss</a></td>
               <td>ruby-rss@ml.commit-email.info</td>
+              <td><a href="mailto:ruby-rss@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby-rss@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ruby/">ruby</a></td>
               <td><a href="https://github.com/ruby/ruby/">ruby</a></td>
               <td>ruby@ml.commit-email.info</td>
+              <td><a href="mailto:ruby@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ruby/">ruby</a></td>
               <td><a href="https://github.com/ruby/strscan/">strscan</a></td>
               <td>ruby-strscan@ml.commit-email.info</td>
+              <td><a href="mailto:ruby-strscan@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby-strscan@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ruby/">ruby</a></td>
               <td><a href="https://github.com/ruby/xmlrpc/">xmlrpc</a></td>
               <td>ruby-xmlrpc@ml.commit-email.info</td>
+              <td><a href="mailto:ruby-xmlrpc@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby-xmlrpc@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/RubyData/">RubyData</a></td>
               <td>(all)</td>
               <td>ruby-data@ml.commit-email.info</td>
+              <td><a href="mailto:ruby-data@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby-data@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ruby-gettext/">ruby-gettext</a></td>
               <td>(all)</td>
               <td>ruby-gettext@ml.commit-email.info</td>
+              <td><a href="mailto:ruby-gettext@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby-gettext@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/ruby-gnome/">ruby-gnome</a></td>
               <td>(all)</td>
               <td>ruby-gnome@ml.commit-email.info</td>
+              <td><a href="mailto:ruby-gnome@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:ruby-gnome@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/rurema/">rurema</a></td>
               <td>(all)</td>
               <td>rurema@ml.commit-email.info</td>
+              <td><a href="mailto:rurema@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:rurema@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/rwiki/">rwiki</a></td>
               <td>(all)</td>
               <td>rwiki@ml.commit-email.info</td>
+              <td><a href="mailto:rwiki@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:rwiki@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/speee/">speee</a></td>
               <td>(all)</td>
               <td>speee@ml.commit-email.info</td>
+              <td><a href="mailto:speee@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:speee@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/speee/">speee</a></td>
               <td><a href="https://github.com/speee/webapp-revieee/">webapp-revieee</a></td>
               <td>speee-webapp-revieee@ml.commit-email.info</td>
+              <td><a href="mailto:speee-webapp-revieee@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:speee-webapp-revieee@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/taiyaki/">taiyaki</a></td>
               <td>(all)</td>
               <td>taiyaki@ml.commit-email.info</td>
+              <td><a href="mailto:taiyaki@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:taiyaki@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/test-unit/">test-unit</a></td>
               <td>(all)</td>
               <td>test-unit@ml.commit-email.info</td>
+              <td><a href="mailto:test-unit@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:test-unit@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/uim/">uim</a></td>
               <td>(all)</td>
               <td>uim@ml.commit-email.info</td>
+              <td><a href="mailto:uim@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:uim@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
               <td><a href="https://github.com/webdino/">webdino</a></td>
               <td>(all)</td>
               <td>webdino@ml.commit-email.info</td>
+              <td><a href="mailto:webdino@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:webdino@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
           </tbody>
         </table>

--- a/ansible/files/var/www/html/index.html
+++ b/ansible/files/var/www/html/index.html
@@ -45,7 +45,7 @@ Subject: Subscribe
 subscribe
         </pre>
 
-        <p>* You can get the mail template by clicking the "Subscribe" button in the list and can send it as it is.</p>
+        <p>* You can get the mail template by clicking the "Subscribe" link in the list and can send it as it is.</p>
       </section>
 
       <section id="unsubscribe">
@@ -65,7 +65,7 @@ Subject: Unsubscribe
 --
         </pre>
 
-        <p>* You can get the mail template by clicking the "Unsubscribe" button in the list and can send it as it is.</p>
+        <p>* You can get the mail template by clicking the "Unsubscribe" link in the list and can send it as it is.</p>
       </section>
     </section>
 


### PR DESCRIPTION
Fix mail addresses into mailto tags so that we can subscribe the address
just by clicking the link and sending the mail, which is automatically created.

I haven't finished this yet.

I will run the rakefile, and check if this is working properly.
I need to add the diff of `index.html` after running the rakefile.
