### PR TITLE
Rename redmine-knowledgebase-migrator to redmine-plugin-wiki-article

### DIFF
--- a/ansible/files/home/mailer/webhook-mailer/config.yaml
+++ b/ansible/files/home/mailer/webhook-mailer/config.yaml
@@ -29,9 +29,6 @@ domains:
       redmine-daily-issue:
         to:
           - clear-code@ml.commit-email.info
-      redmine-knowledgebase-migrator:
-        to:
-          - clear-code@ml.commit-email.info
       redmine-plugin-delayed-job:
         to:
           - clear-code@ml.commit-email.info
@@ -57,6 +54,9 @@ domains:
         to:
           - clear-code@ml.commit-email.info
       redmine-plugin-time-entry-change-notifier:
+        to:
+          - clear-code@ml.commit-email.info
+      redmine-plugin-wiki-article:
         to:
           - clear-code@ml.commit-email.info
       redmine-plugin-work-report-exporter:

--- a/ansible/files/var/www/html/index.html
+++ b/ansible/files/var/www/html/index.html
@@ -122,13 +122,6 @@ Subject: Unsubscribe
               <td><a href="mailto:clear-code@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
-              <td><a href="https://gitlab.com/redmine-knowledgebase-migrator/">redmine-knowledgebase-migrator</a></td>
-              <td>(all)</td>
-              <td>clear-code@ml.commit-email.info</td>
-              <td><a href="mailto:clear-code@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
-              <td><a href="mailto:clear-code@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
-            </tr>
-            <tr>
               <td><a href="https://gitlab.com/redmine-plugin-delayed-job/">redmine-plugin-delayed-job</a></td>
               <td>(all)</td>
               <td>clear-code@ml.commit-email.info</td>
@@ -186,6 +179,13 @@ Subject: Unsubscribe
             </tr>
             <tr>
               <td><a href="https://gitlab.com/redmine-plugin-time-entry-change-notifier/">redmine-plugin-time-entry-change-notifier</a></td>
+              <td>(all)</td>
+              <td>clear-code@ml.commit-email.info</td>
+              <td><a href="mailto:clear-code@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:clear-code@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
+            </tr>
+            <tr>
+              <td><a href="https://gitlab.com/redmine-plugin-wiki-article/">redmine-plugin-wiki-article</a></td>
               <td>(all)</td>
               <td>clear-code@ml.commit-email.info</td>
               <td><a href="mailto:clear-code@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>


### PR DESCRIPTION
https://gitlab.com/redmine-plugin-wiki-article/redmine-plugin-wiki-article

Moved to be in alphabetical order.

I also ran `rake repository:list:update`.