### PR TITLE
Rename redmine-plugin-remote-user-auth to redmine-plugin-auth-remote-user

### DIFF
--- a/ansible/files/home/mailer/webhook-mailer/config.yaml
+++ b/ansible/files/home/mailer/webhook-mailer/config.yaml
@@ -29,6 +29,9 @@ domains:
       redmine-daily-issue:
         to:
           - clear-code@ml.commit-email.info
+      redmine-plugin-auth-remote-user:
+        to:
+          - clear-code@ml.commit-email.info
       redmine-plugin-delayed-job:
         to:
           - clear-code@ml.commit-email.info
@@ -45,9 +48,6 @@ domains:
         to:
           - clear-code@ml.commit-email.info
       redmine-plugin-public-project-permission:
-        to:
-          - clear-code@ml.commit-email.info
-      redmine-plugin-remote-user-auth:
         to:
           - clear-code@ml.commit-email.info
       redmine-plugin-summarized-notification:

--- a/ansible/files/var/www/html/index.html
+++ b/ansible/files/var/www/html/index.html
@@ -122,6 +122,13 @@ Subject: Unsubscribe
               <td><a href="mailto:clear-code@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
             </tr>
             <tr>
+              <td><a href="https://gitlab.com/redmine-plugin-auth-remote-user/">redmine-plugin-auth-remote-user</a></td>
+              <td>(all)</td>
+              <td>clear-code@ml.commit-email.info</td>
+              <td><a href="mailto:clear-code@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
+              <td><a href="mailto:clear-code@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
+            </tr>
+            <tr>
               <td><a href="https://gitlab.com/redmine-plugin-delayed-job/">redmine-plugin-delayed-job</a></td>
               <td>(all)</td>
               <td>clear-code@ml.commit-email.info</td>
@@ -158,13 +165,6 @@ Subject: Unsubscribe
             </tr>
             <tr>
               <td><a href="https://gitlab.com/redmine-plugin-public-project-permission/">redmine-plugin-public-project-permission</a></td>
-              <td>(all)</td>
-              <td>clear-code@ml.commit-email.info</td>
-              <td><a href="mailto:clear-code@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>
-              <td><a href="mailto:clear-code@ml.commit-email.info?subject=Unsubscribe">Unsubscribe</a></td>
-            </tr>
-            <tr>
-              <td><a href="https://gitlab.com/redmine-plugin-remote-user-auth/">redmine-plugin-remote-user-auth</a></td>
               <td>(all)</td>
               <td>clear-code@ml.commit-email.info</td>
               <td><a href="mailto:clear-code@ml.commit-email.info?cc=null@commit-email.info&amp;subject=Subscribe&amp;body=subscribe">Subscribe</a></td>


### PR DESCRIPTION
https://gitlab.com/redmine-plugin-auth-remote-user/redmine-plugin-auth-remote-user/

Moved to be in alphabetical order.
`rake repository:list:update` executed.